### PR TITLE
Lab 1 fix to package name

### DIFF
--- a/labs/1-Create-Catalog-API/README.md
+++ b/labs/1-Create-Catalog-API/README.md
@@ -135,7 +135,7 @@ Containers are extremely useful for hosting service dependencies, but rather tha
 1. Install the `Aspire.Hosting.PostgreSQL` package in the `eShop.AppHost` project:
 
     ```shell
-    dotnet add package Aspire.Hosting.Redis
+    dotnet add package Aspire.Hosting.PostgreSQL
     ```
 
     ```xml


### PR DESCRIPTION
This pull request includes a change in the `labs/1-Create-Catalog-API/README.md` file. The change updates the package to be installed from `Aspire.Hosting.Redis` to `Aspire.Hosting.PostgreSQL`.